### PR TITLE
Adds reload button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ const App: React.FunctionComponent = () => {
 			selectedNetwork
 		);
 		setBusy(false);
+		setConnected(isConnected);
 		return { isConnected, networkId };
 	}
 
@@ -138,7 +139,7 @@ const App: React.FunctionComponent = () => {
 								</Tooltip>
 							}
 						>
-							<Button variant="warning" block size="sm" disabled={busy} onClick={() => connect(network)}>
+							<Button variant="warning" block size="sm" disabled={busy || connected} onClick={() => connect(network)}>
 								<small>Connect</small>
 							</Button>
 						</OverlayTrigger>
@@ -174,8 +175,8 @@ const App: React.FunctionComponent = () => {
 							) : null}
 							<Form.Control type="text" placeholder="Account" value={account} size="sm" readOnly />
 							<InputGroup.Append>
-								<Button variant="warning" block size="sm" disabled={busy} onClick={() => reconnect()}>
-									<small>Reload </small>
+								<Button variant="warning" block size="sm" disabled={busy || !connected} onClick={() => reconnect()}>
+									<small>Connect </small>
 								</Button>
 							</InputGroup.Append>
 						</InputGroup>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,12 @@ const App: React.FunctionComponent = () => {
 		return { isConnected, networkId };
 	}
 
+	async function reconnect() {
+		setBusy(true);
+		await moonbeamLib.reconnect();
+		setBusy(false);
+	}
+
 	async function updateBalance(address: string) {
 		if (address && address !== '') {
 			const readBalance = await moonbeamLib.getTotalBalance(address);
@@ -167,6 +173,11 @@ const App: React.FunctionComponent = () => {
 								</InputGroup.Append>
 							) : null}
 							<Form.Control type="text" placeholder="Account" value={account} size="sm" readOnly />
+							<InputGroup.Append>
+								<Button variant="warning" block size="sm" disabled={busy} onClick={() => reconnect()}>
+									<small>Reload </small>
+								</Button>
+							</InputGroup.Append>
 						</InputGroup>
 						<Networks />
 						{connected ? (
@@ -181,7 +192,7 @@ const App: React.FunctionComponent = () => {
 					</Form.Group>
 					<Form.Group>
 						<Form.Text className="text-muted">
-							<small>BALANCE (MOONBEAM)</small>
+							<small>BALANCE ({network.toUpperCase()})</small>
 						</Form.Text>
 						<InputGroup>
 							<Form.Control type="text" placeholder="0.0" value={balance} size="sm" readOnly />

--- a/src/moonbeam-signer.ts
+++ b/src/moonbeam-signer.ts
@@ -154,7 +154,7 @@ export class MoonbeamLib {
 						onAccountsChanged(accountsRead);
 						provider.on('accountsChanged', async (accounts: string[]) => {
 							if (accounts.length > 0) {
-								const accountsReadAgain = await provider.request({ method: 'eth_accounts' });
+								const accountsReadAgain = await provider.request({ method: 'eth_requestAccounts' });
 								onAccountsChanged(accountsReadAgain);
 							} else {
 								this.isConnected = false;
@@ -182,6 +182,31 @@ export class MoonbeamLib {
 			this.isMoonbeamNetwork = true;
 		}
 		return { isConnected: this.isConnected, networkId };
+	}
+
+	async reconnect() {
+		if ((window as { [key: string]: any }).ethereum) {
+			const provider: any = await this.getProvider();
+			if (provider && provider.isMetaMask) {
+				try {
+					await provider.request({
+						method: 'wallet_requestPermissions',
+						params: [
+							{
+								eth_accounts: {},
+							},
+						],
+					});
+					this.isConnected = true;
+				} catch (e) {
+					if (e.code !== 4001) {
+						throw new Error(e.message);
+					}
+				}
+			} else {
+				throw new Error('Other ethereum wallet did not support.');
+			}
+		}
 	}
 
 	async getAccounts(): Promise<Address[]> {


### PR DESCRIPTION
Remix plugins work with an embedded i-frame site. Therefore, Metamask thinks it is still connected to Remix and not the plugin. When you change accounts, Remix will pick the change, but the plugin will not.

This PR adds a reload button which forces Metamask to ask again about account permission using `wallet_requestPermissions` - This allows for the user to connect another account to the plugin. Once the account is connected, switching does work